### PR TITLE
Get tests to run w/ our latest version of NodeJS

### DIFF
--- a/.github/workflows/node-test-pull.yaml
+++ b/.github/workflows/node-test-pull.yaml
@@ -1,21 +1,25 @@
-# Workflow intended to test PRs 
+# Workflow intended to test PRs
 
-name: CI - Test 
+name: CI - Test
 
-on: 
+on:
   pull_request:
-    
+
 jobs:
   tests:
-    runs-on: ubuntu-latest 
-    
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, '${{ env.NODE_VERSION }}' ]
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup Node.js 
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          node-version: '14'
-      - name: Install Dependencies 
-        run: npm install 
-      - name: Test 
-        run: npm run test 
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
+      - name: Test
+        run: npm run test

--- a/.github/workflows/node-test-pull.yaml
+++ b/.github/workflows/node-test-pull.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, '${{ env.NODE_VERSION }}' ]
+        node-version: [14.x, '${{ vars.NODE_VERSION }}' ]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Over in [`pulsar-edit#1436`](https://github.com/pulsar-edit/pulsar/pull/1436) we were discussing how to minimize the amount of places we have to define the latest version of NodeJS that Pulsar is on, and thus that we want to ensure we are testing against in everything.

My idea was to define an organization level variable that we could easily update with the latest version of NodeJS, and savetheclocktower helpfully suggested we also make sure to leave the last known good version as well.

So this PR attempts this, defining a matrix of tests, with the last known good version for the repo, in this case `v14`, and gets the version from a new organization level actions variable I've made, defining `v20.11.1`.

So lets see if this works the way we want it too.