### PR TITLE
Make this repository publishable to NPM

### DIFF
--- a/.github/workflows/node-test-pull.yaml
+++ b/.github/workflows/node-test-pull.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, '${{ vars.NODE_VERSION }}' ]
+        node-version: [20.x, '${{ vars.NODE_VERSION }}' ]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: NPM Publish
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 20
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+      - name: Install Dependencies
+        run: |
+          npm ci
+      - run: |
+          npm run test
+      - run: npm publish --access public

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 build/
 spec/
-src/
 *.coffee
 .travis.yml
 .npmignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ls-archive",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ls-archive",
-      "version": "1.3.4",
+      "version": "2.0.0",
       "dependencies": {
         "async": "^3.2.6",
         "colors": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ls-archive",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ls-archive",
-  "version": "2.0.0",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pulsar-edit/ls-archive",
   "description": "A package for listing and reading files in archive files",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "licenses": "MIT",
   "keywords": [
     "ls",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pulsar-edit/ls-archive",
   "description": "A package for listing and reading files in archive files",
-  "version": "2.0.0",
+  "version": "1.3.4",
   "licenses": "MIT",
   "keywords": [
     "ls",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ls-archive",
+  "name": "@pulsar-edit/ls-archive",
   "description": "A package for listing and reading files in archive files",
   "version": "1.3.4",
   "licenses": "MIT",


### PR DESCRIPTION
My final PR in this repo (for now)

This PR makes it so we can publish this repository to NPM after we finally land the rest of our changes.

The only thing left would be to allow this repo access to our ORG NPM secret, then bump the version and create a release and we will be good to go!

Then Pulsar can finally get all these updated deps, and further lack of coffeescript 